### PR TITLE
[step23] グローバル変数のサポート

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Rui Ueyama さんの
 ```
 で実行できるようにする予定です。
 
-現在、上記記事の step22 まで実装しており、
+現在、上記記事の step23 まで実装しており、
 - 基本的な単項、二項演算
 	- `+=` のような演算代入や前置/後置のインクリメント/デクリメントにも対応
 	- `sizeof` にも対応していますが、現在整数型を `int` しかサポートしていないため、 `int` として扱われます。
@@ -22,7 +22,7 @@ Rui Ueyama さんの
 	- 現時点では宣言と初期化を同時に行うことができず、`int x; x = 10;` のように書く必要があります。
 	- ポインタは全く同じ型どうしの場合のみに引き算ができ、それらのアドレスオフセットが変数いくつ分になるかが評価値となります。
 - 配列型の変数と添字によるアクセス
-	
+- グローバル変数
 - for, while, if による制御構文
 - コンマによる複数文の記述
 がサポートされています。  
@@ -30,49 +30,27 @@ Rui Ueyama さんの
 ヘッダファイルの include をサポートしていないため、例えば `printf` のような標準ライブラリを使いたい場合などは、別の C ソースでそれらをラップした関数を定義して gcc 等で x86_64 向けにコンパイルした実行オブジェクトを rscc で改めてコンパイルした元のソースにリンクさせて呼び出す必要があります。(以下の `print_helper` はその例です。)
 
 ```C
-int func(int x, int y) {
-	print_helper(x+y);
-	return x + y;
-}
-
-int fib(int N) {
-	if (N <= 2) return 1;
-	return fib(N-1) + fib(N-2);
-}
+int fib(int);
+int MEMO[100];
+int X[10][20][30];
 
 int main() {
-	int i; i = 0;
-	int j; j = 0;
-	int k; k = 1;
-	int sum; sum = 0;
-	for (; i < 10; i+=i+1, j++) {
-		sum++;
-	}
-	print_helper(j);
-	print_helper(k);
-	while (j > 0, 0) {
-		j /= 2;
-		k <<= 1;
-	}
-	if (1 && !(k/2)) k--;
-	else k = -1;
+	int i, x;
+	int *p = &X[0][0][0];
+	int **pp = &p;
+	***X = 10;
 
-	int x, y, z;
-	func(x=1, (y=1, z=~1));
+	for(i=0; i < 100; i++) {
+		MEMO[i] = 0;
+	}
+	
+	print_helper((x = 19, x = fib(*&(**pp))));
+	print_helper(*&(**pp));
+	X[0][3][2] = 99;
+	print_helper(X[0][2][32]);
+	print_helper(sizeof X);
 
-	x = 15 & 10;
-	x = (++x) + y;
-	int *p; p = &x; 
-	int **pp; pp = &p;
-	*p += 9;
 	int X[10][10][10];
-	print_helper(z = fib(*&(**pp)));
-	print_helper(*&*&*&**&*pp);
-	print_helper(sizeof (x+y));
-	print_helper(sizeof ++x);
-	print_helper(sizeof &x + x);
-	print_helper(sizeof(int**));
-	print_helper(sizeof(*p));
 	print_helper(sizeof &X);
 	print_helper(X);
 	print_helper(&X+1);
@@ -81,6 +59,15 @@ int main() {
 	X[0][1][1] = 100;
 	print_helper(*(*(X[0]+1)+1));
 
-	return k;
+	
+	print_helper(fib(50));
+
+	return x;
+}
+
+int fib(int N) {
+	if (N <= 2) return 1;
+	if (MEMO[N-1]) return MEMO[N-1];
+	return MEMO[N-1] = fib(N-1) + fib(N-2);
 }
 ```

--- a/rscc/src/asm.rs
+++ b/rscc/src/asm.rs
@@ -6,7 +6,7 @@ use once_cell::sync::Lazy;
 const UNSUPPORTED_REG_SIZE: &str = "unsupported register size";
 
 pub static ASMCODE: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(
-	"\t.intel_syntax noprefix\n".to_string()
+	"\t.intel_syntax noprefix\n\t.text\n.LText0:\n".to_string()
 ));
 
 pub static ARGS_REGISTERS: Lazy<Mutex<HashMap<usize, Vec<&str>>>> = Lazy::new(|| {
@@ -117,7 +117,7 @@ macro_rules! mov_from {
 #[macro_export]
 macro_rules! mov_glb_addr {
 	($operand:expr, $name:expr) => {
-		asm_write!("\tmov {}, OFFSET FLAT:{}", $operand, $name)
+		asm_write!("\tlea {}, {}[rip]", $operand, $name)
 	};
 }
 
@@ -156,4 +156,3 @@ macro_rules! lea {
 		asm_write!("\tlea {}, [{}-{}]", $operand1, $operand2, $offset)
 	};
 }
-

--- a/rscc/src/asm.rs
+++ b/rscc/src/asm.rs
@@ -79,11 +79,20 @@ macro_rules! mov_glb_addr {
 }
 
 #[macro_export]
-macro_rules! mov_to_glb {
-	($operand:expr, $name:expr) => {
+macro_rules! mov_from_glb {
+	($size:expr, $operand:expr, $name:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASM.try_lock().unwrap() += format!("\tmov {} {}[rip], {}\n", $operand, _word, $name).as_str()
+		*ASM.try_lock().unwrap() += format!("\tmov {}, {} {}[rip]\n", $operand, _word, $name).as_str()
+	};
+}
+
+#[macro_export]
+macro_rules! mov_to_glb {
+	($size:expr, $operand:expr, $name:expr) => {
+		use crate::asm::word_ptr;
+		let _word = word_ptr($size);
+		*ASM.try_lock().unwrap() += format!("\tmov {} {}[rip], {}\n", _word, $name, $operand).as_str()
 	};
 }
 

--- a/rscc/src/asm.rs
+++ b/rscc/src/asm.rs
@@ -1,6 +1,38 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
 
 const UNSUPPORTED_REG_SIZE: &str = "unsupported register size";
 
+pub static ASMCODE: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(
+	"\t.intel_syntax noprefix\n".to_string()
+));
+
+pub static ARGS_REGISTERS: Lazy<Mutex<HashMap<usize, Vec<&str>>>> = Lazy::new(|| {
+	let mut map = HashMap::new();
+	let _ = map.insert(4, vec!["edi", "esi", "edx", "rcx", "r8d", "r9d"]);
+	let _ = map.insert(8, vec!["rdi", "rsi", "rdx", "rcx", "r8", "r9"]);
+	Mutex::new(map)
+});
+
+static CTRL_COUNT: Lazy<Mutex<u32>> = Lazy::new(|| Mutex::new(0));
+static FUNC_COUNT: Lazy<Mutex<u32>> = Lazy::new(|| Mutex::new(0));
+
+// CTRL_COUNT にアクセスして分岐ラベルのための値を得つつインクリメントする
+pub fn get_ctrl_count() -> u32 {
+	let mut count = CTRL_COUNT.try_lock().unwrap();
+	let c = *count;
+	*count += 1;
+	c
+}
+
+pub fn get_func_count() -> u32 {
+	let mut count = FUNC_COUNT.try_lock().unwrap();
+	let c = *count;
+	*count += 1;
+	c
+}
 
 pub fn reg_ax(size: usize) -> &'static str {
 	match size {
@@ -27,17 +59,28 @@ pub fn word_ptr(size: usize) -> &'static str {
 }
 
 #[macro_export]
+macro_rules! asm_write {
+	($fmt: expr) => {
+		*ASMCODE.try_lock().unwrap() += format!($fmt).as_str()
+	};
+
+	($fmt: expr, $($arg: tt)*) =>{
+		*ASMCODE.try_lock().unwrap() += format!($fmt, $($arg)*).as_str()
+	};
+}
+
+#[macro_export]
 macro_rules! operate {
 	($operator:expr) => {
-		*ASM.try_lock().unwrap() += format!("\t{}\n", $operator).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\t{}\n", $operator).as_str()
 	};
 	
 	($operator:expr, $operand1:expr) => {
-		*ASM.try_lock().unwrap() += format!("\t{} {}\n", $operator, $operand1).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\t{} {}\n", $operator, $operand1).as_str()
 	};
 	
 	($operator:expr, $operand1:expr, $operand2:expr) => {
-		*ASM.try_lock().unwrap() += format!("\t{} {}, {}\n", $operator, $operand1, $operand2).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\t{} {}, {}\n", $operator, $operand1, $operand2).as_str()
 	};
 }
 
@@ -46,13 +89,13 @@ macro_rules! mov_to {
 	($size:expr, $operand1:expr, $operand2:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASM.try_lock().unwrap() += format!("\tmov {} [{}], {}\n", _word, $operand1, $operand2).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\tmov {} [{}], {}\n", _word, $operand1, $operand2).as_str()
 	};
 
 	($size:expr, $operand1:expr, $operand2:expr, $offset:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASM.try_lock().unwrap() += format!("\tmov {} [{}-{}], {}\n", _word, $operand1, $offset, $operand2).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\tmov {} [{}-{}], {}\n", _word, $operand1, $offset, $operand2).as_str()
 	};
 }
 
@@ -61,20 +104,20 @@ macro_rules! mov_from {
 	($size:expr, $operand1:expr, $operand2:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASM.try_lock().unwrap() += format!("\tmov {}, {} [{}]\n", $operand1, _word, $operand2).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\tmov {}, {} [{}]\n", $operand1, _word, $operand2).as_str()
 	};
 
 	($size:expr, $operand1:expr, $operand2:expr, $offset:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASM.try_lock().unwrap() += format!("\tmov {}, {} [{}-{}]\n", $operand1, _word,$operand2, $offset).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\tmov {}, {} [{}-{}]\n", $operand1, _word,$operand2, $offset).as_str()
 	};
 }
 
 #[macro_export]
 macro_rules! mov_glb_addr {
 	($operand:expr, $name:expr) => {
-		*ASM.try_lock().unwrap() += format!("\tmov {}, OFFSET FLAT:{}\n", $operand, $name).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\tmov {}, OFFSET FLAT:{}\n", $operand, $name).as_str()
 	};
 }
 
@@ -83,7 +126,7 @@ macro_rules! mov_from_glb {
 	($size:expr, $operand:expr, $name:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASM.try_lock().unwrap() += format!("\tmov {}, {} {}[rip]\n", $operand, _word, $name).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\tmov {}, {} {}[rip]\n", $operand, _word, $name).as_str()
 	};
 }
 
@@ -92,35 +135,25 @@ macro_rules! mov_to_glb {
 	($size:expr, $operand:expr, $name:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASM.try_lock().unwrap() += format!("\tmov {} {}[rip], {}\n", _word, $name, $operand).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\tmov {} {}[rip], {}\n", _word, $name, $operand).as_str()
 	};
 }
 
 #[macro_export]
 macro_rules! mov {
 	($operand1:expr, $operand2:expr) => {
-		*ASM.try_lock().unwrap() += format!("\tmov {}, {}\n", $operand1, $operand2).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\tmov {}, {}\n", $operand1, $operand2).as_str()
 	};
 }
 
 #[macro_export]
 macro_rules! lea {
 	($operand1:expr, $operand2:expr) => {
-		*ASM.try_lock().unwrap() += format!("\tlea {}, [{}]\n", $operand1, $operand2).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\tlea {}, [{}]\n", $operand1, $operand2).as_str()
 	};
 
 	($operand1:expr, $operand2:expr, $offset:expr) => {
-		*ASM.try_lock().unwrap() += format!("\tlea {}, [{}-{}]\n", $operand1, $operand2, $offset).as_str()
+		*ASMCODE.try_lock().unwrap() += format!("\tlea {}, [{}-{}]\n", $operand1, $operand2, $offset).as_str()
 	};
 }
 
-#[macro_export]
-macro_rules! asm_write {
-	($fmt: expr) => {
-		*ASM.try_lock().unwrap() += format!($fmt).as_str()
-	};
-
-	($fmt: expr, $($arg: tt)*) =>{
-		*ASM.try_lock().unwrap() += format!($fmt, $($arg)*).as_str()
-	};
-}

--- a/rscc/src/asm.rs
+++ b/rscc/src/asm.rs
@@ -72,6 +72,22 @@ macro_rules! mov_from {
 }
 
 #[macro_export]
+macro_rules! mov_glb_addr {
+	($operand:expr, $name:expr) => {
+		*ASM.try_lock().unwrap() += format!("\tmov {}, OFFSET FLAT:{}\n", $operand, $name).as_str()
+	};
+}
+
+#[macro_export]
+macro_rules! mov_to_glb {
+	($operand:expr, $name:expr) => {
+		use crate::asm::word_ptr;
+		let _word = word_ptr($size);
+		*ASM.try_lock().unwrap() += format!("\tmov {} {}[rip], {}\n", $operand, _word, $name).as_str()
+	};
+}
+
+#[macro_export]
 macro_rules! mov {
 	($operand1:expr, $operand2:expr) => {
 		*ASM.try_lock().unwrap() += format!("\tmov {}, {}\n", $operand1, $operand2).as_str()

--- a/rscc/src/asm.rs
+++ b/rscc/src/asm.rs
@@ -61,26 +61,26 @@ pub fn word_ptr(size: usize) -> &'static str {
 #[macro_export]
 macro_rules! asm_write {
 	($fmt: expr) => {
-		*ASMCODE.try_lock().unwrap() += format!($fmt).as_str()
+		*ASMCODE.try_lock().unwrap() += format!(concat!($fmt, "\n")).as_str()
 	};
 
 	($fmt: expr, $($arg: tt)*) =>{
-		*ASMCODE.try_lock().unwrap() += format!($fmt, $($arg)*).as_str()
+		*ASMCODE.try_lock().unwrap() += format!(concat!($fmt, "\n"), $($arg)*).as_str()
 	};
 }
 
 #[macro_export]
 macro_rules! operate {
 	($operator:expr) => {
-		*ASMCODE.try_lock().unwrap() += format!("\t{}\n", $operator).as_str()
+		asm_write!("\t{}", $operator)
 	};
 	
 	($operator:expr, $operand1:expr) => {
-		*ASMCODE.try_lock().unwrap() += format!("\t{} {}\n", $operator, $operand1).as_str()
+		asm_write!("\t{} {}", $operator, $operand1)
 	};
 	
 	($operator:expr, $operand1:expr, $operand2:expr) => {
-		*ASMCODE.try_lock().unwrap() += format!("\t{} {}, {}\n", $operator, $operand1, $operand2).as_str()
+		asm_write!("\t{} {}, {}", $operator, $operand1, $operand2)
 	};
 }
 
@@ -89,13 +89,13 @@ macro_rules! mov_to {
 	($size:expr, $operand1:expr, $operand2:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASMCODE.try_lock().unwrap() += format!("\tmov {} [{}], {}\n", _word, $operand1, $operand2).as_str()
+		asm_write!("\tmov {} [{}], {}", _word, $operand1, $operand2)
 	};
 
 	($size:expr, $operand1:expr, $operand2:expr, $offset:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASMCODE.try_lock().unwrap() += format!("\tmov {} [{}-{}], {}\n", _word, $operand1, $offset, $operand2).as_str()
+		asm_write!("\tmov {} [{}-{}], {}", _word, $operand1, $offset, $operand2)
 	};
 }
 
@@ -104,20 +104,20 @@ macro_rules! mov_from {
 	($size:expr, $operand1:expr, $operand2:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASMCODE.try_lock().unwrap() += format!("\tmov {}, {} [{}]\n", $operand1, _word, $operand2).as_str()
+		asm_write!("\tmov {}, {} [{}]", $operand1, _word, $operand2)
 	};
 
 	($size:expr, $operand1:expr, $operand2:expr, $offset:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASMCODE.try_lock().unwrap() += format!("\tmov {}, {} [{}-{}]\n", $operand1, _word,$operand2, $offset).as_str()
+		asm_write!("\tmov {}, {} [{}-{}]", $operand1, _word,$operand2, $offset)
 	};
 }
 
 #[macro_export]
 macro_rules! mov_glb_addr {
 	($operand:expr, $name:expr) => {
-		*ASMCODE.try_lock().unwrap() += format!("\tmov {}, OFFSET FLAT:{}\n", $operand, $name).as_str()
+		asm_write!("\tmov {}, OFFSET FLAT:{}", $operand, $name)
 	};
 }
 
@@ -126,7 +126,7 @@ macro_rules! mov_from_glb {
 	($size:expr, $operand:expr, $name:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASMCODE.try_lock().unwrap() += format!("\tmov {}, {} {}[rip]\n", $operand, _word, $name).as_str()
+		asm_write!("\tmov {}, {} {}[rip]", $operand, _word, $name)
 	};
 }
 
@@ -135,25 +135,25 @@ macro_rules! mov_to_glb {
 	($size:expr, $operand:expr, $name:expr) => {
 		use crate::asm::word_ptr;
 		let _word = word_ptr($size);
-		*ASMCODE.try_lock().unwrap() += format!("\tmov {} {}[rip], {}\n", _word, $name, $operand).as_str()
+		asm_write!("\tmov {} {}[rip], {}", _word, $name, $operand)
 	};
 }
 
 #[macro_export]
 macro_rules! mov {
 	($operand1:expr, $operand2:expr) => {
-		*ASMCODE.try_lock().unwrap() += format!("\tmov {}, {}\n", $operand1, $operand2).as_str()
+		asm_write!("\tmov {}, {}", $operand1, $operand2)
 	};
 }
 
 #[macro_export]
 macro_rules! lea {
 	($operand1:expr, $operand2:expr) => {
-		*ASMCODE.try_lock().unwrap() += format!("\tlea {}, [{}]\n", $operand1, $operand2).as_str()
+		asm_write!("\tlea {}, [{}]", $operand1, $operand2)
 	};
 
 	($operand1:expr, $operand2:expr, $offset:expr) => {
-		*ASMCODE.try_lock().unwrap() += format!("\tlea {}, [{}-{}]\n", $operand1, $operand2, $offset).as_str()
+		asm_write!("\tlea {}, [{}-{}]", $operand1, $operand2, $offset)
 	};
 }
 

--- a/rscc/src/generator.rs
+++ b/rscc/src/generator.rs
@@ -56,8 +56,8 @@ pub fn gen_expr(node: &NodeRef) {
 				// 現在はグローバル変数の初期化はサポートしないため、常に .bss で指定
 				let bytes = node.typ.as_ref().unwrap().bytes();
 				asm_write!("\t.globl {}", name);
-				asm_write!("\t.type {}, @object", name);
 				asm_write!("\t.bss");
+				asm_write!("\t.type {}, @object", name);
 				asm_write!("\t.size {}, {}", name, bytes);
 				asm_write!("{}:", name);
 				asm_write!("\t.zero {}", bytes);

--- a/rscc/src/generator.rs
+++ b/rscc/src/generator.rs
@@ -38,7 +38,7 @@ fn get_count() -> u32 {
 
 pub fn gen_expr(node: &NodeRef) {
 	match node.borrow().kind {
-		Nodekind::FuncDecNd => {
+		Nodekind::GlobalNd => {
 			{
 				asm_write!("{}:\n", node.borrow().name.as_ref().unwrap());
 			

--- a/rscc/src/generator.rs
+++ b/rscc/src/generator.rs
@@ -198,7 +198,7 @@ pub fn gen_expr(node: &NodeRef) {
 			gen_addr(node.borrow().left.as_ref().unwrap());
 			return;
 		}
-		Nodekind::FuncNd => {
+		Nodekind::FunCallNd => {
 			// 引数をレジスタに格納する処理
 			push_args(&node.borrow().args);
 			

--- a/rscc/src/main.rs
+++ b/rscc/src/main.rs
@@ -13,7 +13,8 @@ mod token;
 mod tokenizer;
 mod typecell; // type が予約語だったので typecell とした
 mod utils;
-use generator::{gen_expr, ASM};
+use asm::ASMCODE;
+use generator::gen_expr;
 use options::Opts;
 use parser::program;
 use token::TokenRef;
@@ -40,7 +41,7 @@ fn main() {
 		}
 
 		// 最後に一気に書き込み
-		println!("{}", *ASM.try_lock().unwrap());
+		println!("{}", *ASMCODE.try_lock().unwrap());
 
     } else {
 		// fileが指定されていない場合、exit

--- a/rscc/src/node.rs
+++ b/rscc/src/node.rs
@@ -77,7 +77,6 @@ pub struct Node {
 	pub args: Vec<Option<NodeRef>>,
 	pub stmts: Option<Vec<NodeRef>>,
 	pub max_offset: Option<usize>,
-	pub ret_typ: Option<TypeCell>,
 
 	// 変数時に使用
 	pub is_local: bool,
@@ -86,7 +85,7 @@ pub struct Node {
 // 初期化を簡単にするためにデフォルトを定義
 impl Default for Node {
 	fn default() -> Node {
-		Node {kind: Nodekind::DefaultNd, token: None, typ: None, val: None, offset: None, left: None, right: None, init: None, enter: None, routine: None, branch: None, els: None, children: vec![], name: None, func_typ: None, args: vec![], stmts: None, max_offset: None, ret_typ: None, is_local: false }
+		Node {kind: Nodekind::DefaultNd, token: None, typ: None, val: None, offset: None, left: None, right: None, init: None, enter: None, routine: None, branch: None, els: None, children: vec![], name: None, func_typ: None, args: vec![], stmts: None, max_offset: None, is_local: false }
 	}
 }
 
@@ -142,7 +141,6 @@ impl Display for Node {
 
 		if let Some(e) = self.stmts.as_ref() {s = format!("{}stmts: exist({})\n", s, e.len());}
 		if let Some(e) = self.max_offset.as_ref() {s = format!("{}max_offset: {}\n", s, e);}
-		if let Some(e) = self.ret_typ.as_ref() {s = format!("{}return type: {}\n", s, e);}
 
 		write!(f, "{}", s)
 	}

--- a/rscc/src/node.rs
+++ b/rscc/src/node.rs
@@ -45,6 +45,7 @@ pub enum Nodekind {
 	GlobalNd,	// グローバル変数(関数含む)
 }
 
+#[derive(Clone, Debug)]
 pub struct Node {
 	pub kind: Nodekind, // Nodeの種類
 	pub token: Option<TokenRef>, // 対応する Token (エラーメッセージに必要)
@@ -81,6 +82,10 @@ pub struct Node {
 	// 変数時に使用
 	pub is_local: bool,
 }
+
+// 並列で処理することがないものとして、グローバル変数の都合で Send/Sync を使う
+unsafe impl Send for Node {}
+unsafe impl Sync for Node {}
 
 // 初期化を簡単にするためにデフォルトを定義
 impl Default for Node {

--- a/rscc/src/node.rs
+++ b/rscc/src/node.rs
@@ -41,7 +41,7 @@ pub enum Nodekind {
 	ReturnNd,	// "return"
 	BlockNd,	// {}
 	CommaNd,	// ','
-	FuncNd,		// func()
+	FunCallNd,	// func()
 	GlobalNd,	// グローバル変数(関数含む)
 }
 
@@ -68,13 +68,13 @@ pub struct Node {
 	// {children}: ほんとはOptionのVecである必要はない気がするが、ジェネレータとの互換を考えてOptionに揃える
 	pub children: Vec<Option<NodeRef>>,
 
-	// func の引数を保存する 
-	pub args: Vec<Option<NodeRef>>,
 
 	// グローバル変数等で使用
 	pub name: Option<String>,
 
-	// 関数宣言時に使用
+	// 関数に使用
+	pub func_typ: Option<TypeCell>,
+	pub args: Vec<Option<NodeRef>>,
 	pub stmts: Option<Vec<NodeRef>>,
 	pub max_offset: Option<usize>,
 	pub ret_typ: Option<TypeCell>,
@@ -86,7 +86,7 @@ pub struct Node {
 // 初期化を簡単にするためにデフォルトを定義
 impl Default for Node {
 	fn default() -> Node {
-		Node {kind: Nodekind::DefaultNd, token: None, typ: None, val: None, offset: None, left: None, right: None, init: None, enter: None, routine: None, branch: None, els: None, children: vec![], args: vec![], name: None, stmts: None, max_offset: None, ret_typ: None, is_local: false }
+		Node {kind: Nodekind::DefaultNd, token: None, typ: None, val: None, offset: None, left: None, right: None, init: None, enter: None, routine: None, branch: None, els: None, children: vec![], name: None, func_typ: None, args: vec![], stmts: None, max_offset: None, ret_typ: None, is_local: false }
 	}
 }
 
@@ -131,6 +131,7 @@ impl Display for Node {
 			}
 		}
 
+		if let Some(e) = self.func_typ.as_ref() {s = format!("{}function type: {}\n", s, e);}
 		if self.args.len() > 0 {
 			s = format!("{}args: exist\n", s);
 			for node in &self.args {

--- a/rscc/src/node.rs
+++ b/rscc/src/node.rs
@@ -42,7 +42,7 @@ pub enum Nodekind {
 	BlockNd,	// {}
 	CommaNd,	// ','
 	FuncNd,		// func()
-	FuncDecNd,	// 関数の宣言
+	GlobalNd,	// グローバル変数(関数含む)
 }
 
 pub struct Node {
@@ -71,7 +71,7 @@ pub struct Node {
 	// func の引数を保存する 
 	pub args: Vec<Option<NodeRef>>,
 
-	// func 時に使用(もしかしたらグローバル変数とかでも使うかも？)
+	// グローバル変数等で使用
 	pub name: Option<String>,
 
 	// 関数宣言時に使用
@@ -166,7 +166,7 @@ mod tests {
 	fn display() {
 		println!("{}", Node::default());
 		let node: Node = Node {
-			kind: Nodekind::FuncDecNd,
+			kind: Nodekind::GlobalNd,
 			stmts: Some(vec![
 				Rc::new(RefCell::new(Node::default())),
 				Rc::new(RefCell::new(Node {kind: Nodekind::AddNd, ..Default::default()})),

--- a/rscc/src/node.rs
+++ b/rscc/src/node.rs
@@ -78,12 +78,15 @@ pub struct Node {
 	pub stmts: Option<Vec<NodeRef>>,
 	pub max_offset: Option<usize>,
 	pub ret_typ: Option<TypeCell>,
+
+	// 変数時に使用
+	pub is_local: bool,
 }
 
 // 初期化を簡単にするためにデフォルトを定義
 impl Default for Node {
 	fn default() -> Node {
-		Node {kind: Nodekind::DefaultNd, token: None, typ: None, val: None, offset: None, left: None, right: None, init: None, enter: None, routine: None, branch: None, els: None, children: vec![], args: vec![], name: None, stmts: None, max_offset: None, ret_typ: None }
+		Node {kind: Nodekind::DefaultNd, token: None, typ: None, val: None, offset: None, left: None, right: None, init: None, enter: None, routine: None, branch: None, els: None, children: vec![], args: vec![], name: None, stmts: None, max_offset: None, ret_typ: None, is_local: false }
 	}
 }
 
@@ -92,7 +95,13 @@ impl Display for Node {
 	fn fmt(&self, f:&mut Formatter) -> Result {
 
 		let mut s = format!("{}\n", "-".to_string().repeat(REP_NODE));
-		s = format!("{}Nodekind : {:?}\n", s, self.kind);
+		let scope_attr = 
+		if self.kind == Nodekind::LvarNd {
+			if self.is_local { "<Local>" } else { "<Global>"}
+		} else {
+			""
+		};
+		s = format!("{}Nodekind : {:?}{}\n", s, self.kind, scope_attr);
 
 		if let Some(e) = self.typ.as_ref() {s = format!("{}type: {}\n", s, e);}
 		if let Some(e) = self.token.as_ref() {

--- a/rscc/src/parser.rs
+++ b/rscc/src/parser.rs
@@ -518,7 +518,9 @@ fn stmt(token_ptr: &mut TokenRef) -> NodeRef {
 		loop {
 			if !consume(token_ptr, "}") {
 				if at_eof(token_ptr) {exit_eprintln!("\'{{\'にマッチする\'}}\'が見つかりません。");}
-				children.push(Some(stmt(token_ptr)));
+				let _stmt = stmt(token_ptr);
+				confirm_type(&_stmt);
+				children.push(Some(_stmt));
 			} else {
 				break;
 			}
@@ -527,20 +529,41 @@ fn stmt(token_ptr: &mut TokenRef) -> NodeRef {
 
 	} else if consume(token_ptr, "if") {
 		expect(token_ptr, "(");
-		let enter= Some(expr(token_ptr));
+		let enter= {
+			let _enter = expr(token_ptr);
+			confirm_type(&_enter);
+			Some(_enter)
+		};
 		expect(token_ptr, ")");
 
-		let branch = Some(stmt(token_ptr));
-		let els = if consume(token_ptr, "else") {Some(stmt(token_ptr))} else {None};
+		let branch = {
+			let _branch = stmt(token_ptr);
+			confirm_type(&_branch);
+			Some(_branch)
+		};
+
+		let els = if consume(token_ptr, "else") {
+			let _els = stmt(token_ptr);
+			confirm_type(&_els);
+			Some(_els)
+		} else {None};
 		
 		new_ctrl(Nodekind::IfNd, None, enter, None, branch, els)
 
 	} else if consume(token_ptr, "while") {
 		expect(token_ptr, "(");
-		let enter = Some(expr(token_ptr));
+		let enter= {
+			let _enter = expr(token_ptr);
+			confirm_type(&_enter);
+			Some(_enter)
+		};
 		expect(token_ptr, ")");
 
-		let branch = Some(stmt(token_ptr));
+		let branch = {
+			let _branch = stmt(token_ptr);
+			confirm_type(&_branch);
+			Some(_branch)
+		};
 
 		new_ctrl(Nodekind::WhileNd, None, enter, None, branch, None)
 
@@ -549,24 +572,35 @@ fn stmt(token_ptr: &mut TokenRef) -> NodeRef {
 		// consumeできた場合exprが何も書かれていないことに注意
 		let init: Option<NodeRef> =
 		if consume(token_ptr, ";") {None} else {
-			let init_ = Some(expr(token_ptr));
+			let _init = {
+				let __init = expr(token_ptr);
+				confirm_type(&__init);
+				Some(__init)
+			};
 			expect(token_ptr, ";");
-			init_
+			_init
 		};
 
 		let enter: Option<NodeRef> =
 		if consume(token_ptr, ";") {None} else {
-			let enter_ = Some(expr(token_ptr));
+			let _enter = {
+				let __enter = expr(token_ptr);
+				confirm_type(&__enter);
+				Some(__enter)
+			};
 			expect(token_ptr, ";");
-			enter_
+			_enter
 		};
 
 		let routine: Option<NodeRef> = 
 		if consume(token_ptr, ")") {None} else {
-			let routine_ = Some(expr(token_ptr));
-			// confirm_type(&routine_.as_ref().unwrap());
+			let _routine = {
+				let __routine = expr(token_ptr);
+				confirm_type(&__routine);
+				Some(__routine)
+			};
 			expect(token_ptr, ")");
-			routine_
+			_routine
 		};
 
 		let branch: Option<NodeRef> = Some(stmt(token_ptr));
@@ -579,10 +613,10 @@ fn stmt(token_ptr: &mut TokenRef) -> NodeRef {
 		if consume(token_ptr, ";") {
 			tmp_num!(0)
 		} else {
-			let left_: NodeRef = expr(token_ptr);
-			confirm_type(&left_);
+			let _left: NodeRef = expr(token_ptr);
+			confirm_type(&_left);
 			expect(token_ptr, ";");
-			left_
+			_left
 		};
 
 		new_unary(Nodekind::ReturnNd, left, ptr)

--- a/rscc/src/parser.rs
+++ b/rscc/src/parser.rs
@@ -318,7 +318,7 @@ fn func_args(token_ptr: &mut TokenRef) -> Vec<Option<NodeRef>> {
 }
 
 // 生成規則: 
-// program = (type ident "(" func-args ")" "{" stmt* "}")*
+// program = global*
 pub fn program(token_ptr: &mut TokenRef) -> Vec<NodeRef> {
 	let mut globals : Vec<NodeRef> = Vec::new();
 
@@ -370,6 +370,13 @@ pub fn program(token_ptr: &mut TokenRef) -> Vec<NodeRef> {
 	}
 	
 	globals
+}
+
+// 生成規則:
+// global = type ident global-suffix
+// global-suffix = "(" func-args ")" "{" stmt* "}" | ("[" num "]")* ";"
+fn global(token_ptr: &mut TokenRef) -> NodeRef {
+	tmp_num!(0)
 }
 
 // 生成規則:
@@ -1017,7 +1024,6 @@ fn primary(token_ptr: &mut TokenRef) -> NodeRef {
 
 			let mut node_ptr = new_lvar(name, ptr.clone(), typ.clone());
 
-			// TODO: 添字による配列アクセス ... X[10] -> *(X+10)
 			while consume(token_ptr, "[") {
 				let index_ptr = token_ptr.clone();
 				let index = expr(token_ptr);

--- a/rscc/src/parser.rs
+++ b/rscc/src/parser.rs
@@ -156,8 +156,7 @@ fn new_ctrl(kind: Nodekind,
 // 関数呼び出しのノード
 fn new_func(name: String, func_typ: TypeCell, args: Vec<Option<NodeRef>>, token_ptr: TokenRef) -> NodeRef {
 	if func_typ.typ != Type::Func { panic!("new_func can be called only with function TypeCell"); }
-	let ret_typ = func_typ.ret_typ.clone().unwrap().borrow().clone();
-	Rc::new(RefCell::new(Node{ kind: Nodekind::FunCallNd, token: Some(token_ptr), name: Some(name), func_typ:Some(func_typ), args: args, ret_typ: Some(ret_typ), ..Default::default()}))
+	Rc::new(RefCell::new(Node{ kind: Nodekind::FunCallNd, token: Some(token_ptr), name: Some(name), func_typ:Some(func_typ), args: args, ..Default::default()}))
 }
 
 // グローバル変数のノード(new_gvar, new_funcdec によりラップして使う)
@@ -274,9 +273,9 @@ fn confirm_type(node: &NodeRef) {
 			);
 		}
 		Nodekind::FunCallNd => {
-			// FunCallNd には ret_typ があるが、これを typ にも適用することで自然に型を親ノードに伝播できる
+			// FunCallNd の func_typ.ret_typ を typ に適用することで自然に型を親ノードに伝播できる
 			let mut node = node.borrow_mut();
-			let typ = node.ret_typ.clone().unwrap();
+			let typ = node.func_typ.as_ref().unwrap().ret_typ.as_ref().unwrap().borrow().clone();
 			let _ = node.typ.insert(typ);
 		}
 		_ => {}

--- a/rscc/src/parser.rs
+++ b/rscc/src/parser.rs
@@ -85,7 +85,7 @@ macro_rules! tmp_num {
 // 左辺値に対応するノード: += などの都合で無名の変数を生成する場合があるため、token は Option で受ける
 fn _lvar(name: impl Into<String>, token: Option<TokenRef>, typ: Option<TypeCell>, is_local: bool) -> NodeRef {
 	let name: String = name.into();
-	let offset: Option<usize> =
+	let (offset, name): (Option<usize>, Option<String>) =
 	if is_local {
 		let _offset: usize;
 		// デッドロック回避のため、フラグを用意してmatch内で再度LOCALS(<変数名, オフセット>のHashMap)にアクセスしないようにする
@@ -122,10 +122,11 @@ fn _lvar(name: impl Into<String>, token: Option<TokenRef>, typ: Option<TypeCell>
 				local_access.insert(name, (_offset, TypeCell::default()));
 			}
 		}
-		Some(_offset)
-	} else { None };
+		(Some(_offset), None)
+	} else { (None, Some(name)) };
+
 	
-	Rc::new(RefCell::new(Node{ kind: Nodekind::LvarNd, typ: typ, token: token, offset: offset, is_local: is_local, .. Default::default()}))
+	Rc::new(RefCell::new(Node{ kind: Nodekind::LvarNd, typ: typ, token: token, offset: offset, name: name, is_local: is_local, .. Default::default()}))
 }
 
 fn new_lvar(name: impl Into<String>, token_ptr: TokenRef, typ: TypeCell, is_local: bool) -> NodeRef {

--- a/rscc/src/parser.rs
+++ b/rscc/src/parser.rs
@@ -1,5 +1,5 @@
 // 再帰下降構文のパーサ
-use std::{cell::RefCell, convert::TryInto};
+use std::{cell::RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Mutex;

--- a/rscc/src/parser.rs
+++ b/rscc/src/parser.rs
@@ -163,20 +163,20 @@ fn new_func(name: String, func_typ: TypeCell, args: Vec<Option<NodeRef>>, token_
 }
 
 // グローバル変数のノード(new_gvar, new_funcdec によりラップして使う)
-fn _global(name: String, typ: Option<TypeCell>, func_typ: Option<TypeCell>, args: Vec<Option<NodeRef>>, stmts: Option<Vec<NodeRef>>, token_ptr: TokenRef) -> NodeRef {
-	Rc::new(RefCell::new(Node{ kind: Nodekind::GlobalNd, token: Some(token_ptr), typ:typ, name: Some(name), func_typ: func_typ, args: args, stmts: stmts, ..Default::default() }))
+fn _global(name: String, typ: Option<TypeCell>, func_typ: Option<TypeCell>, args: Vec<Option<NodeRef>>, stmts: Option<Vec<NodeRef>>, max_offset: Option<usize>, token_ptr: TokenRef) -> NodeRef {
+	Rc::new(RefCell::new(Node{ kind: Nodekind::GlobalNd, token: Some(token_ptr), typ:typ, name: Some(name), func_typ: func_typ, args: args, stmts: stmts, max_offset: max_offset, ..Default::default() }))
 }
 
 fn new_gvar(name: String, typ: TypeCell, token_ptr: TokenRef) -> NodeRef {
-	_global(name, Some(typ), None, vec![], None, token_ptr)
+	_global(name, Some(typ), None, vec![], None, None, token_ptr)
 }
 
-fn new_funcdec(name: String, func_typ: TypeCell, args: Vec<Option<NodeRef>>, stmts: Vec<NodeRef>, token_ptr: TokenRef) -> NodeRef {
-	_global(name, None, Some(func_typ), args, Some(stmts), token_ptr)
+fn new_funcdec(name: String, func_typ: TypeCell, args: Vec<Option<NodeRef>>, stmts: Vec<NodeRef>, max_offset: usize, token_ptr: TokenRef) -> NodeRef {
+	_global(name, None, Some(func_typ), args, Some(stmts), Some(max_offset), token_ptr)
 }
 
 fn proto_funcdec(name: String, func_typ: TypeCell, token_ptr: TokenRef) -> NodeRef {
-	_global(name, None, Some(func_typ), vec![], None, token_ptr)
+	_global(name, None, Some(func_typ), vec![], None, None, token_ptr)
 }
 
 
@@ -372,8 +372,9 @@ fn global(token_ptr: &mut TokenRef) -> NodeRef {
 			if !has_return {
 				stmts.push(tmp_unary!(Nodekind::ReturnNd, tmp_num!(0)));
 			}
+			let max_offset = *LVAR_MAX_OFFSET.try_lock().unwrap();
 
-			new_funcdec(name.clone(), typ.clone(), args, stmts, ptr)
+			new_funcdec(name.clone(), typ.clone(), args, stmts, max_offset, ptr)
 
 		} else {
 			expect(token_ptr, ";");

--- a/rscc/src/typecell.rs
+++ b/rscc/src/typecell.rs
@@ -123,6 +123,13 @@ impl TypeCell {
 				format!("*{}", s)
 			};
 			(*deref).borrow().get_type_string(string)
+		} else if self.typ == Type::Func {
+			let ret_typ = self.ret_typ.as_ref().unwrap().borrow().clone();
+			let mut args_str = String::new();
+			for (ix, arg) in self.arg_typs.as_ref().unwrap().iter().enumerate() {
+				args_str = if ix == 0 { format!("{}", arg.borrow()) } else { format!("{}, {}", args_str, arg.borrow()) };
+			}
+			format!("{} __func({}){}", ret_typ, args_str,s)
 		} else {
 			format!("{}{}", self.typ, s)
 		}

--- a/rscc/src/typecell.rs
+++ b/rscc/src/typecell.rs
@@ -160,7 +160,8 @@ impl PartialEq for TypeCell {
 				false
 			}
 		} else {
-			self.typ == other.typ
+			self.typ == other.typ && self.ret_typ == other.ret_typ && self.arg_typs == other.arg_typs
+
 		}
 	}
 }

--- a/rscc/src/typecell.rs
+++ b/rscc/src/typecell.rs
@@ -10,6 +10,7 @@ pub enum Type {
 	Invalid, // デフォルトや無名ノードに割り当てる
 	Int,
 	Ptr,
+	Func,
 	Array,
 }
 
@@ -20,6 +21,7 @@ impl Type {
 			Type::Int => { 4 }
 			Type::Ptr => { 8 }
 			Type::Array => { panic!("cannot infer size of array from only itself"); }
+			Type::Func => { panic!("access to the size of function should not be implemented yet"); }
 		}
 	}
 }
@@ -32,6 +34,7 @@ impl Display for Type {
 			Type::Int => { s = "int"; }
 			Type::Ptr => { s = "pointer"; }
 			Type::Array => { s = "array"; }
+			Type::Func => { s = "function"; }
 		}
 		write!(f, "{}", s)
 	}
@@ -48,6 +51,11 @@ pub struct TypeCell {
 	pub ptr_end: Option<Type>,
 	pub chains: usize,
 	pub array_size: Option<usize>,
+
+	// self.typ == Type::Func
+	pub ret_typ: Option<TypeCellRef>,
+	pub arg_typs: Option<Vec<TypeCellRef>>,
+
 }
 
 impl TypeCell {
@@ -68,7 +76,7 @@ impl TypeCell {
 		let array_of = Some(Rc::new(RefCell::new(self.clone())));
 		let ptr_end = if self.typ == Type::Array { self.ptr_end.clone() } else { Some(self.typ) };
 		let chains = self.chains + 1;
-		TypeCell { typ: Type::Array, ptr_to: array_of, ptr_end: ptr_end, chains: chains, array_size: Some(size) }
+		TypeCell { typ: Type::Array, ptr_to: array_of, ptr_end: ptr_end, chains: chains, array_size: Some(size), ..Default::default() }
 	}
 
 	// 配列の次元と最小要素の型情報を取得
@@ -86,6 +94,12 @@ impl TypeCell {
 	pub fn make_deref(&self) -> Self {
 		if ![Type::Array, Type::Ptr].contains(&self.typ) { panic!("not able to extract element from non-array"); } 
 		(*self.ptr_to.clone().unwrap().borrow()).clone()
+	}
+
+	pub fn make_func(ret_typ: Self, arg_typs: Vec<TypeCellRef>) -> Self {
+		let _ret_typ = Some(Rc::new(RefCell::new(ret_typ)));
+		let _arg_typs = Some(arg_typs);
+		TypeCell { typ: Type::Func, ret_typ: _ret_typ, arg_typs: _arg_typs, ..Default::default() }
 	}
 
 	pub fn bytes(&self) -> usize {
@@ -117,7 +131,7 @@ impl TypeCell {
 
 impl Default for TypeCell {
 	fn default() -> Self {
-		TypeCell { typ: Type::Invalid, ptr_to: None, ptr_end: None, chains: 0, array_size: None}
+		TypeCell { typ: Type::Invalid, ptr_to: None, ptr_end: None, chains: 0, array_size: None, arg_typs: None, ret_typ: None}
 	}
 }
 


### PR DESCRIPTION
- program 生成規則の変更が必要
- ローカル変数との名前被りは、ローカルとグローバルのマップを持って先に前者をルックアップすることで解決する
- 宣言時の初期化は行わないことにする