### PR TITLE
ローカル変数の初期化のサポート

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rui Ueyama さんの
 ```
 で実行できるようにする予定です。
 
-現在、上記記事の step27 まで実装しており、
+現在、上記記事の step は全て実装済みで、
 - 基本的な単項、二項演算
 	- `+=` のような演算代入や前置/後置のインクリメント/デクリメントにも対応
 	- `sizeof` にも対応していますが、現在整数型を `int` しかサポートしていないため、 `int` として扱われます。
@@ -21,6 +21,7 @@ Rui Ueyama さんの
 	- ポインタは全く同じ型どうしの場合のみに引き算ができ、それらのアドレスオフセットが変数いくつ分になるかが評価値となります。
 	- スタックにプッシュする値を全て8バイトで処理している関係で、符号拡張などが甘い部分があります。今後修正予定です。
 - 配列型の変数と添字によるアクセス
+- ローカル変数宣言時の初期化;
 - グローバル変数
 - 文字列リテラル及び char リテラル
 	- utf-8 です
@@ -65,8 +66,12 @@ int main() {
 	char *str = "This is test script";
 	showChar(str[13], str[14], str[15], str[16], str[17], str[18]);
 
+	char str2[] = {"This is test script",}, str3[] = "rustcc";
+	showChar(str2[13], str2[14], str2[15], str2[16], str2[17], str2[18]);
+	showChar(str3[0], str3[1], str3[2], str3[3], str3[4], str3[5]);
+
 	char lf = 10;
-	printf_wrap("This is test script for step%d%c", 'a'-70, lf);
+	printf_wrap("This is test script for step%d%c", 'a'-69, lf);
 
 	return x;
 }
@@ -85,12 +90,14 @@ int fib(int N) {
 I got 99 as argument.
 I got 24000 as argument.
 I got 8 as argument.
-I got 274903112992 as argument.
-I got 274903113392 as argument.
-I got 274903116992 as argument.
+I got 274903117088 as argument.
+I got 274903117488 as argument.
+I got 274903121088 as argument.
 I got 55 as argument.
 I got 3996334433 as argument.
 showChar called, message is "script"
-This is test script for step27
+showChar called, message is "script"
+showChar called, message is "rustcc"
+This is test script for step28
 55
 ```

--- a/rscc/src/asm.rs
+++ b/rscc/src/asm.rs
@@ -69,6 +69,7 @@ pub fn reg_di(size: usize) -> &'static str {
 pub fn word_ptr(size: usize) -> &'static str {
 	match size {
 		1 => { "BYTE PTR" }
+		2 => { "WORD PTR" }
 		4 => { "DWORD PTR" }
 		8 => { "QWORD PTR" }
 		_ => { panic!("{}", UNSUPPORTED_REG_SIZE); }

--- a/rscc/src/generator.rs
+++ b/rscc/src/generator.rs
@@ -5,12 +5,12 @@ use crate::{
 		cast, get_ctrl_count, get_func_count, reg_ax, reg_di, word_ptr
 	},
 	node::{Nodekind, NodeRef},
-	parser::LITERALS,
+	parser::ORDERED_LITERALS,
 	typecell::Type
 };
 
 pub fn load_literals() {
-	let literals_access = LITERALS.try_lock().unwrap();
+	let literals_access = ORDERED_LITERALS.try_lock().unwrap();
 	if literals_access.is_empty() { return; }
 
 	asm_write!("\t.section .rodata"); // read-only data

--- a/rscc/src/generator.rs
+++ b/rscc/src/generator.rs
@@ -369,6 +369,36 @@ pub fn gen_expr(node: &NodeRef) {
 
 			return;
 		}
+		Nodekind::ZeroClrNd => {
+			// これは特殊な Node で、現時点では left に LvarNd が繋がっているパターンしかあり得ない
+			let left = node.borrow().left.clone().unwrap();
+			let mut bytes = left.borrow().typ.clone().unwrap().bytes();
+			let mut offset = left.borrow().offset.unwrap();
+			for i in 0..bytes/8 {
+				mov_to!(8, "rbp", 0, offset);
+				offset -= 8;
+			}
+			bytes %= 8;
+			if bytes/4 == 1 {
+				mov_to!(4, "rbp", 0, offset);
+				offset -= 4;
+			}
+			bytes %= 4;
+			if bytes/2 == 1 {
+				mov_to!(2, "rbp", 0, offset);
+				offset -= 2;
+			}
+			bytes %= 2;
+			if bytes == 1 {
+				mov_to!(4, "rbp", 0, offset);
+			}
+			operate!("push", 0);
+			return;
+		}
+		Nodekind::NopNd => {
+			operate!("push", 0);
+			return;
+		}
 		_ => {}// 他のパターンなら、ここでは何もしない
 	} 
 

--- a/rscc/src/generator.rs
+++ b/rscc/src/generator.rs
@@ -372,31 +372,17 @@ pub fn gen_expr(node: &NodeRef) {
 		Nodekind::ZeroClrNd => {
 			// これは特殊な Node で、現時点では left に LvarNd が繋がっているパターンしかあり得ない
 			let left = node.borrow().left.clone().unwrap();
-			let mut bytes = left.borrow().typ.clone().unwrap().bytes();
-			let mut offset = left.borrow().offset.unwrap();
-			for i in 0..bytes/8 {
-				mov_to!(8, "rbp", 0, offset);
-				offset -= 8;
-			}
-			bytes %= 8;
-			if bytes/4 == 1 {
-				mov_to!(4, "rbp", 0, offset);
-				offset -= 4;
-			}
-			bytes %= 4;
-			if bytes/2 == 1 {
-				mov_to!(2, "rbp", 0, offset);
-				offset -= 2;
-			}
-			bytes %= 2;
-			if bytes == 1 {
-				mov_to!(4, "rbp", 0, offset);
-			}
+			let offset = left.borrow().offset.unwrap();
+			let bytes = left.borrow().typ.clone().unwrap().bytes();
+			
+			zero_clear(offset, bytes);
 			operate!("push", 0);
+
 			return;
 		}
 		Nodekind::NopNd => {
 			operate!("push", 0);
+
 			return;
 		}
 		_ => {}// 他のパターンなら、ここでは何もしない
@@ -545,6 +531,37 @@ fn push_args(args: &Vec<Option<NodeRef>>) {
 			movsx!("rax", "al");
 		}
 		mov!(arg_reg, ax);
+	}
+}
+
+// rbp - offset から rbp - offset + bytes までゼロクリアを行う
+fn zero_clear(mut offset: usize, mut bytes: usize) {
+	if bytes >= 128 {
+		lea!("rdi", "rbp", offset);
+		mov!("rax", 0);
+		mov!("rcx", bytes/8);
+		operate!("rep", "stosq");
+		mov!("eax", 0);
+		offset -= (bytes/8)*8;
+	} else {
+		for _ in 0..bytes/8 {
+		mov_to!(8, "rbp", 0, offset);
+		offset -= 8;
+		}
+	}
+	bytes %= 8;
+	if bytes/4 == 1 {
+		mov_to!(4, "rbp", 0, offset);
+		offset -= 4;
+	}
+	bytes %= 4;
+	if bytes/2 == 1 {
+		mov_to!(2, "rbp", 0, offset);
+		offset -= 2;
+	}
+	bytes %= 2;
+	if bytes == 1 {
+		mov_to!(1, "rbp", 0, offset);
 	}
 }
 
@@ -919,6 +936,26 @@ mod tests {
 			int main() {
 				return fib(10);
 			}
+		";
+		test_init(src);
+
+		let mut token_ptr = tokenize(0);
+		let node_heads = program(&mut token_ptr);
+		for node_ptr in node_heads {
+			gen_expr(&node_ptr);
+		}
+		println!("{}", ASMCODE.try_lock().unwrap());
+	}
+
+	#[test]
+	fn zero_clear_() {
+		let src: &str = "
+			int main() {
+			char X[][9][33] = {{1}, 3};
+			char Y[127] = {0};
+			int Z[15] = {0};
+			return 0;
+		}
 		";
 		test_init(src);
 

--- a/rscc/src/initializer.rs
+++ b/rscc/src/initializer.rs
@@ -13,7 +13,7 @@ pub struct Initializer {
 	pub node:		Option<NodeRef>,		// 初期化する値に対応する式 
 	pub typ:		Option<TypeCell>,		// タイプ
 	pub elements:	Vec<InitializerRef>,	// 配列の各要素
-	// pub is_flex:	bool,					// 配列サイズを指定しない初期化
+	pub is_literal: bool,					// リテラルに起因する char[] の場合のみ使用する
 }
 
 impl Initializer {

--- a/rscc/src/initializer.rs
+++ b/rscc/src/initializer.rs
@@ -23,29 +23,16 @@ impl Default for Initializer {
 }
 
 impl Initializer {
-	pub fn new(typ: &TypeCell, is_flex: bool) -> Self {
-		match typ.typ {
-			Type::Array => {
-				if let Some(array_size) = typ.array_size {
-					let mut elements = vec![];
-					let elem_typ = typ.make_deref();
-					for _ in 0..array_size {
-						elements.push(Rc::new(RefCell::new(
-							Initializer::new(&elem_typ, false)
-						)));
-					}
-					Initializer { typ: Some(typ.clone()), elements: elements, ..Default::default() }
-				} else {
-					// flexible array
-					if !is_flex { panic!("array flexibility conflicts."); }
-					Initializer { typ: Some(typ.clone()), is_flex: true, ..Default::default() }
-				}
+	pub fn new(typ: &TypeCell) -> Self {
+		Initializer { typ: Some(typ.clone()), ..Default::default() }
+	}
 
-			},
-			_ => {
-				Initializer { typ: Some(typ.clone()), ..Default::default() }
-			}
-		}
+	pub fn new_with_node(typ: &TypeCell, node: &NodeRef) -> Self {
+		Initializer { node: Some(Rc::clone(node)), typ: Some(typ.clone()), ..Default::default() }
+	}
+
+	pub fn push_element(&mut self,  elem: Initializer) {
+		self.elements.push(Rc::new(RefCell::new(elem)));
 	}
 }
 

--- a/rscc/src/initializer.rs
+++ b/rscc/src/initializer.rs
@@ -32,20 +32,17 @@ impl Initializer {
 	}
 
 	// 配列サイズを指定していない場合のサイズ特定を行う
+	// parser::make_lvar_init と似たような処理
 	pub fn flex_elem_count(&self) -> usize {
 		if self.is_element() { panic!("invalid function on elemental initializer"); }
+		let elem_flatten_size = self.elements[0].borrow().typ.as_ref().unwrap().flatten_size();
 		let mut count = 0;
-		// ネストされているものは1つとして読む
-		for elem in self.elements.iter() {
-			if !elem.borrow().is_element() {
-				count += 1;
-			} else { break; }
+		let mut ix = 0;
+		while ix < self.elements.len() {
+			ix += if self.elements[ix].borrow().is_element() { elem_flatten_size } else { 1 };
+			count += 1;
 		}
-		// 残りはそれぞれベース要素として読む
-		let elem_size = self.elements[0].borrow().typ.clone().unwrap().flatten_size();
-		let rem_count = ((self.elements.len() - count) + elem_size - 1)/ elem_size;
-
-		count + rem_count
+		count
 	}
 }
 

--- a/rscc/src/initializer.rs
+++ b/rscc/src/initializer.rs
@@ -21,8 +21,31 @@ impl Initializer {
 		Initializer { node: Some(Rc::clone(node)), typ: Some(typ.clone()), ..Default::default() }
 	}
 
+	#[inline]
 	pub fn push_element(&mut self,  elem: Initializer) {
 		self.elements.push(Rc::new(RefCell::new(elem)));
+	}
+	
+	#[inline]
+	pub fn is_element(&self) -> bool {
+		self.elements.is_empty()
+	}
+
+	// 配列サイズを指定していない場合のサイズ特定を行う
+	pub fn flex_elem_count(&self) -> usize {
+		if self.is_element() { panic!("invalid function on elemental initializer"); }
+		let mut count = 0;
+		// ネストされているものは1つとして読む
+		for elem in self.elements.iter() {
+			if !elem.borrow().is_element() {
+				count += 1;
+			} else { break; }
+		}
+		// 残りはそれぞれベース要素として読む
+		let elem_size = self.elements[0].borrow().typ.clone().unwrap().flatten_size();
+		let rem_count = ((self.elements.len() - count) + elem_size - 1)/ elem_size;
+
+		count + rem_count
 	}
 }
 

--- a/rscc/src/initializer.rs
+++ b/rscc/src/initializer.rs
@@ -1,0 +1,59 @@
+use std::rc::Rc;
+use std::cell::RefCell;
+
+use crate::{
+	node::NodeRef,
+	typecell::{Type, TypeCell},
+};
+
+pub type InitializerRef = Rc<RefCell<Initializer>>;
+
+#[derive(Debug)]
+pub struct Initializer {
+	pub node:		Option<NodeRef>,		// 初期化する値に対応する式 
+	pub typ:		Option<TypeCell>,		// タイプ
+	pub elements:	Vec<InitializerRef>,	// 配列の各要素
+	pub is_flex:	bool,					// 配列サイズを指定しない初期化
+}
+
+impl Default for Initializer {
+	fn default() -> Initializer {
+		Initializer {node: None, typ: None, elements: vec![], is_flex: false }
+	}
+}
+
+impl Initializer {
+	pub fn new(typ: &TypeCell, is_flex: bool) -> Self {
+		match typ.typ {
+			Type::Array => {
+				if let Some(array_size) = typ.array_size {
+					let mut elements = vec![];
+					let elem_typ = typ.make_deref();
+					for _ in 0..array_size {
+						elements.push(Rc::new(RefCell::new(
+							Initializer::new(&elem_typ, false)
+						)));
+					}
+					Initializer { typ: Some(typ.clone()), elements: elements, ..Default::default() }
+				} else {
+					// flexible array
+					if !is_flex { panic!("array flexibility conflicts."); }
+					Initializer { typ: Some(typ.clone()), is_flex: true, ..Default::default() }
+				}
+
+			},
+			_ => {
+				Initializer { typ: Some(typ.clone()), ..Default::default() }
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn display() {
+	}
+}

--- a/rscc/src/initializer.rs
+++ b/rscc/src/initializer.rs
@@ -3,23 +3,17 @@ use std::cell::RefCell;
 
 use crate::{
 	node::NodeRef,
-	typecell::{Type, TypeCell},
+	typecell::TypeCell,
 };
 
 pub type InitializerRef = Rc<RefCell<Initializer>>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Initializer {
 	pub node:		Option<NodeRef>,		// 初期化する値に対応する式 
 	pub typ:		Option<TypeCell>,		// タイプ
 	pub elements:	Vec<InitializerRef>,	// 配列の各要素
 	pub is_flex:	bool,					// 配列サイズを指定しない初期化
-}
-
-impl Default for Initializer {
-	fn default() -> Initializer {
-		Initializer {node: None, typ: None, elements: vec![], is_flex: false }
-	}
 }
 
 impl Initializer {

--- a/rscc/src/initializer.rs
+++ b/rscc/src/initializer.rs
@@ -13,12 +13,19 @@ pub struct Initializer {
 	pub node:		Option<NodeRef>,		// 初期化する値に対応する式 
 	pub typ:		Option<TypeCell>,		// タイプ
 	pub elements:	Vec<InitializerRef>,	// 配列の各要素
-	pub is_flex:	bool,					// 配列サイズを指定しない初期化
+	// pub is_flex:	bool,					// 配列サイズを指定しない初期化
 }
 
 impl Initializer {
+	#[inline]
 	pub fn new(typ: &TypeCell, node: &NodeRef) -> Self {
 		Initializer { node: Some(Rc::clone(node)), typ: Some(typ.clone()), ..Default::default() }
+	}
+
+	#[inline]
+	pub fn insert(&mut self, typ: &TypeCell, node: &NodeRef) {
+		let _ = self.typ.insert(typ.clone());
+		let _ = self.node.insert(Rc::clone(node));
 	}
 
 	#[inline]

--- a/rscc/src/initializer.rs
+++ b/rscc/src/initializer.rs
@@ -23,11 +23,7 @@ impl Default for Initializer {
 }
 
 impl Initializer {
-	pub fn new(typ: &TypeCell) -> Self {
-		Initializer { typ: Some(typ.clone()), ..Default::default() }
-	}
-
-	pub fn new_with_node(typ: &TypeCell, node: &NodeRef) -> Self {
+	pub fn new(typ: &TypeCell, node: &NodeRef) -> Self {
 		Initializer { node: Some(Rc::clone(node)), typ: Some(typ.clone()), ..Default::default() }
 	}
 

--- a/rscc/src/initializer.rs
+++ b/rscc/src/initializer.rs
@@ -34,6 +34,12 @@ impl Initializer {
 	}
 	
 	#[inline]
+	pub fn append_elements(&mut self, elem: Initializer) {
+		let mut append_elems = elem.elements.clone();
+		self.elements.append(&mut append_elems);
+	}
+
+	#[inline]
 	pub fn is_element(&self) -> bool {
 		self.elements.is_empty()
 	}
@@ -42,7 +48,7 @@ impl Initializer {
 	// parser::make_lvar_init と似たような処理
 	pub fn flex_elem_count(&self) -> usize {
 		if self.is_element() { panic!("invalid function on elemental initializer"); }
-		let elem_flatten_size = self.elements[0].borrow().typ.as_ref().unwrap().flatten_size();
+		let elem_flatten_size = self.typ.as_ref().unwrap().make_deref().unwrap().flatten_size();
 		let mut count = 0;
 		let mut ix = 0;
 		while ix < self.elements.len() {

--- a/rscc/src/initializer.rs
+++ b/rscc/src/initializer.rs
@@ -45,12 +45,3 @@ impl Initializer {
 		count
 	}
 }
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn display() {
-	}
-}

--- a/rscc/src/main.rs
+++ b/rscc/src/main.rs
@@ -6,6 +6,7 @@ use clap::Clap;
 mod asm;
 mod generator;
 mod globals;
+mod initializer;
 mod node;
 mod options;
 mod parser;

--- a/rscc/src/node.rs
+++ b/rscc/src/node.rs
@@ -44,7 +44,8 @@ pub enum Nodekind {
 	CommaNd,	// ','
 	FunCallNd,	// func()
 	GlobalNd,	// グローバル変数(関数含む)
-	ZeroClearNd,	// スタックのゼロクリア(配列の初期化など)
+	ZeroClrNd,	// スタックのゼロクリア(配列の初期化など)
+	NopNd,		// 何もしない
 }
 
 #[derive(Clone, Debug)]

--- a/rscc/src/node.rs
+++ b/rscc/src/node.rs
@@ -44,6 +44,7 @@ pub enum Nodekind {
 	CommaNd,	// ','
 	FunCallNd,	// func()
 	GlobalNd,	// グローバル変数(関数含む)
+	ZeroClearNd,	// スタックのゼロクリア(配列の初期化など)
 }
 
 #[derive(Clone, Debug)]

--- a/rscc/src/parser.rs
+++ b/rscc/src/parser.rs
@@ -532,6 +532,8 @@ fn declaration(token_ptr: &mut TokenRef) -> NodeRef {
 fn lvar_decl(token_ptr: &mut TokenRef, mut typ: TypeCell) -> NodeRef {
 	let ptr = token_ptr.clone();
 	let name = expect_ident(token_ptr);
+	if LOCALS.try_lock().unwrap().contains_key(&name) { error_with_token!("既に宣言された変数です。", &ptr.borrow()); }
+
 	let mut is_flex = false;
 
 	if consume(token_ptr, "[") {
@@ -545,6 +547,7 @@ fn lvar_decl(token_ptr: &mut TokenRef, mut typ: TypeCell) -> NodeRef {
 	} else {
 		// 初期化しない場合は何もアセンブリを吐かない
 		if is_flex { error_with_token!("初期化しない場合は完全な配列サイズが必要です。", &ptr.borrow()); }
+		let _ = new_lvar(name, ptr, typ, true);
 		nop()
 	}
 }

--- a/rscc/src/parser.rs
+++ b/rscc/src/parser.rs
@@ -255,9 +255,7 @@ fn confirm_type(node: &NodeRef) {
 			}
 
 			if let Some(_) = &typ.ptr_end {
-				// left がポインタ型だということなので、 chains は必ず正であり、1ならば参照外し後は値に、そうでなければ配列 or ポインタになることに注意
-				// 配列かポインタかを継承するために typ.typ を使う
-				let _ = node.typ.insert( typ.make_deref() );
+				let _ = node.typ.insert( typ.make_deref().unwrap() );
 			} else {
 				error_with_node!("\"*\"ではポインタの参照を外すことができますが、型\"{}\"が指定されています。", &node, typ.typ);
 			}
@@ -564,7 +562,7 @@ fn initializer(token_ptr: &mut TokenRef, typ: &TypeCell) -> Initializer {
 // 生成規則:
 // array-initializer = (initializer ("," initializer)* ","? "}"
 fn array_initializer(token_ptr: &mut TokenRef, typ: &TypeCell) -> Initializer {
-	let elem_typ = typ.make_deref();
+	let elem_typ = if let Ok(_typ) = typ.make_deref() { _typ } else { typ.clone() };
 	let first_elem = initializer(token_ptr, &elem_typ);
 	// 配列の Initializer の node は最初の要素を指すことにする
 	let mut init = Initializer::new(typ, first_elem.node.as_ref().unwrap()); 

--- a/rscc/src/token.rs
+++ b/rscc/src/token.rs
@@ -169,9 +169,9 @@ impl Display for Token {
 }
 
 // トークンのポインタを読み進める
+#[inline]
 pub fn token_ptr_exceed(token_ptr: &mut TokenRef) {
 	let tmp_ptr;
-
 	// next が None なら exit
 	match token_ptr.borrow().next.as_ref() {
 		Some(ptr) => {

--- a/rscc/src/tokenizer.rs
+++ b/rscc/src/tokenizer.rs
@@ -89,10 +89,11 @@ pub fn tokenize(file_num: usize) -> TokenRef {
 				}
 
 				// C ではソース上での文字列リテラルの改行は認められていないので、行ごとのループ内でリテラルを読む処理を完結させて良い
+				let line_offset = lookat; // 文字列の先頭を指すように　line_offset を押さえておく
 				match read_str_literal(&string, &mut lookat, len) {
 					Ok(literal) => {
 						if let Some(body) = literal {
-							token_ptr.borrow_mut().next = Some(Rc::new(RefCell::new(Token::new(Tokenkind::StringTk, body, file_num, line_num, lookat))));
+							token_ptr.borrow_mut().next = Some(Rc::new(RefCell::new(Token::new(Tokenkind::StringTk, body, file_num, line_num, line_offset))));
 							token_ptr_exceed(&mut token_ptr);
 							continue;
 						}
@@ -106,7 +107,7 @@ pub fn tokenize(file_num: usize) -> TokenRef {
 				match read_char_literal(&string, &mut lookat, len) {
 					Ok(encoded) => {
 						if let Some(val) = encoded {
-							token_ptr.borrow_mut().next = Some(Rc::new(RefCell::new(Token::new(Tokenkind::NumTk, val.to_string(), file_num, line_num, lookat))));
+							token_ptr.borrow_mut().next = Some(Rc::new(RefCell::new(Token::new(Tokenkind::NumTk, val.to_string(), file_num, line_num, line_offset))));
 							token_ptr_exceed(&mut token_ptr);
 							continue;
 						}

--- a/rscc/src/tokenizer.rs
+++ b/rscc/src/tokenizer.rs
@@ -411,16 +411,16 @@ pub fn expect_type(token_ptr: &mut TokenRef) -> TypeCell {
 // 期待する次のトークンを(文字列で)指定して読む関数(失敗するとfalseを返す)
 pub fn consume(token_ptr: &mut TokenRef, op: &str) -> bool {
 	if is(token_ptr, op) {
-		false
-	} else {
 		token_ptr_exceed(token_ptr);
 		true
+	} else {
+		false
 	}
 }
 
 #[inline]
 pub fn is(token_ptr: &mut TokenRef, op: &str) -> bool {
-	token_ptr.borrow().kind != Tokenkind::ReservedTk || token_ptr.borrow().body.as_ref().unwrap() != op 
+	token_ptr.borrow().kind == Tokenkind::ReservedTk && token_ptr.borrow().body.as_ref().unwrap() == op 
 }
 
 // 期待する次のトークンを(Tokenkindで)指定して読む関数(失敗するとfalseを返す)

--- a/rscc/src/tokenizer.rs
+++ b/rscc/src/tokenizer.rs
@@ -456,19 +456,17 @@ pub fn consume_type(token_ptr: &mut TokenRef) -> Option<TypeCell> {
 	}
 }
 
-pub fn expect_literal(token_ptr: &mut TokenRef) -> &str {
+pub fn expect_literal(token_ptr: &mut TokenRef) -> String {
 	if is_kind(token_ptr, Tokenkind::StringTk) {
 		token_ptr_exceed(token_ptr);
-		let literal = token_ptr.borrow().body.clone().unwrap();
-		// TODO: スコープ管理
-		literal
+		 token_ptr.borrow().body.clone().unwrap()
 	} else {
 		error_with_token!("文字列リテラルを期待した位置で予約されていないトークン\"{}\"が発見されました。", &*token_ptr.borrow(), token_ptr.borrow().body.as_ref().unwrap());
 	}
 }
 
 #[inline]
-pub fn consume_literal(token_ptr: &mut TokenRef) -> Option<&str> {
+pub fn consume_literal(token_ptr: &mut TokenRef) -> Option<String> {
 	if is_kind(token_ptr, Tokenkind::StringTk) {
 		Some(expect_literal(token_ptr))
 	} else {

--- a/rscc/src/tokenizer.rs
+++ b/rscc/src/tokenizer.rs
@@ -432,19 +432,45 @@ pub fn consume_number(token_ptr: &mut TokenRef) -> Option<i32> {
 	}
 }
 
+#[inline]
+pub fn is_kind(token_ptr: &mut TokenRef, kind: Tokenkind) -> bool {
+	token_ptr.borrow().kind == kind
+}
+
 // 期待する次のトークンを(Tokenkindで)指定して読む関数(失敗するとfalseを返す)
 pub fn consume_kind(token_ptr: &mut TokenRef, kind: Tokenkind) -> bool {
-	if token_ptr.borrow().kind != kind {
-		false
-	} else {
+	if is_kind(token_ptr, kind) {
 		token_ptr_exceed(token_ptr);
 		true
+	} else {
+		false
 	}
 }
 
+#[inline]
 pub fn consume_type(token_ptr: &mut TokenRef) -> Option<TypeCell> {
 	if is_type(token_ptr) {
 		Some(expect_type(token_ptr))
+	} else {
+		None
+	}
+}
+
+pub fn expect_literal(token_ptr: &mut TokenRef) -> &str {
+	if is_kind(token_ptr, Tokenkind::StringTk) {
+		token_ptr_exceed(token_ptr);
+		let literal = token_ptr.borrow().body.clone().unwrap();
+		// TODO: スコープ管理
+		literal
+	} else {
+		error_with_token!("文字列リテラルを期待した位置で予約されていないトークン\"{}\"が発見されました。", &*token_ptr.borrow(), token_ptr.borrow().body.as_ref().unwrap());
+	}
+}
+
+#[inline]
+pub fn consume_literal(token_ptr: &mut TokenRef) -> Option<&str> {
+	if is_kind(token_ptr, Tokenkind::StringTk) {
+		Some(expect_literal(token_ptr))
 	} else {
 		None
 	}

--- a/rscc/src/tokenizer.rs
+++ b/rscc/src/tokenizer.rs
@@ -458,8 +458,9 @@ pub fn consume_type(token_ptr: &mut TokenRef) -> Option<TypeCell> {
 
 pub fn expect_literal(token_ptr: &mut TokenRef) -> String {
 	if is_kind(token_ptr, Tokenkind::StringTk) {
+		let literal = token_ptr.borrow().body.clone().unwrap();
 		token_ptr_exceed(token_ptr);
-		 token_ptr.borrow().body.clone().unwrap()
+		literal
 	} else {
 		error_with_token!("文字列リテラルを期待した位置で予約されていないトークン\"{}\"が発見されました。", &*token_ptr.borrow(), token_ptr.borrow().body.as_ref().unwrap());
 	}

--- a/rscc/src/tokenizer.rs
+++ b/rscc/src/tokenizer.rs
@@ -410,11 +410,25 @@ pub fn expect_type(token_ptr: &mut TokenRef) -> TypeCell {
 
 // 期待する次のトークンを(文字列で)指定して読む関数(失敗するとfalseを返す)
 pub fn consume(token_ptr: &mut TokenRef, op: &str) -> bool {
-	if token_ptr.borrow().kind != Tokenkind::ReservedTk || token_ptr.borrow().body.as_ref().unwrap() != op {
+	if is(token_ptr, op) {
 		false
 	} else {
 		token_ptr_exceed(token_ptr);
 		true
+	}
+}
+
+#[inline]
+pub fn is(token_ptr: &mut TokenRef, op: &str) -> bool {
+	token_ptr.borrow().kind != Tokenkind::ReservedTk || token_ptr.borrow().body.as_ref().unwrap() != op 
+}
+
+// 期待する次のトークンを(Tokenkindで)指定して読む関数(失敗するとfalseを返す)
+pub fn consume_number(token_ptr: &mut TokenRef) -> Option<i32> {
+	if token_ptr.borrow().kind == Tokenkind::NumTk {
+		Some(expect_number(token_ptr))
+	} else {
+		None
 	}
 }
 
@@ -436,6 +450,7 @@ pub fn consume_type(token_ptr: &mut TokenRef) -> Option<TypeCell> {
 	}
 }
 
+#[inline]
 pub fn is_type(token_ptr: &mut TokenRef) -> bool {
 	token_ptr.borrow().kind == Tokenkind::ReservedTk && TYPES.try_lock().unwrap().contains_key(token_ptr.borrow().body.as_ref().unwrap()) 
 }

--- a/rscc/src/typecell.rs
+++ b/rscc/src/typecell.rs
@@ -129,6 +129,11 @@ impl TypeCell {
 		dim.iter().product::<usize>()
 	}
 
+	#[inline]
+	pub fn is_char_1d_array(&self) -> bool {
+		self.typ == Type::Array && self.make_deref().unwrap().typ == Type::Char
+	}
+
 	pub fn bytes(&self) -> usize {
 		match self.typ {
 			Type::Array => {

--- a/rscc/src/typecell.rs
+++ b/rscc/src/typecell.rs
@@ -68,8 +68,25 @@ pub struct TypeCell {
 }
 
 impl TypeCell {
+
+	#[inline]
 	pub fn new(typ: Type) -> Self {
 		TypeCell { typ: typ, ..Default::default()}
+	}
+
+	#[inline]
+	pub fn is_array(&self) -> bool {
+		self.typ == Type::Array
+	}
+	
+	#[inline]
+	pub fn is_non_array(&self) -> bool {
+		self.typ != Type::Array
+	}
+
+	#[inline]
+	pub fn is_one_of(&self, types: &[Type]) -> bool {
+		types.contains(&self.typ)
 	}
 
 	pub fn make_ptr_to(&self) -> Self {
@@ -102,7 +119,7 @@ impl TypeCell {
 
 	#[inline]
 	pub fn make_deref(&self) -> Result<Self, ()> {
-		if [Type::Array, Type::Ptr].contains(&self.typ) {
+		if self.is_one_of(&[Type::Array, Type::Ptr]) {
 			Ok((*self.ptr_to.clone().unwrap().borrow()).clone())
 		} else { Err(()) }
 	}

--- a/rscc/src/typecell.rs
+++ b/rscc/src/typecell.rs
@@ -100,9 +100,10 @@ impl TypeCell {
 		}
 	}
 
-	pub fn make_deref(&self) -> Self {
-		if ![Type::Array, Type::Ptr].contains(&self.typ) { panic!("not able to extract element from non-array"); } 
-		(*self.ptr_to.clone().unwrap().borrow()).clone()
+	pub fn make_deref(&self) -> Result<Self, ()> {
+		if [Type::Array, Type::Ptr].contains(&self.typ) {
+			Ok((*self.ptr_to.clone().unwrap().borrow()).clone())
+		} else { Err(()) }
 	}
 
 	pub fn make_func(ret_typ: Self, arg_typs: Vec<TypeCellRef>) -> Self {

--- a/rscc/src/typecell.rs
+++ b/rscc/src/typecell.rs
@@ -144,6 +144,15 @@ impl TypeCell {
 		}
 	}
 
+	pub fn get_last_level_array(&self) -> Option<TypeCell> {
+		let (dim, typ) = self.array_dim();
+		if let Some(d) = dim.last() {
+			Some(typ.make_array_of(*d))
+		} else {
+			None
+		}
+	}
+
 	fn get_type_string(&self, s: impl Into<String>) -> String {
 		let s = s.into();
 		if let Some(deref) = &self.ptr_to {

--- a/rscc/src/typecell.rs
+++ b/rscc/src/typecell.rs
@@ -100,16 +100,33 @@ impl TypeCell {
 		}
 	}
 
+	#[inline]
 	pub fn make_deref(&self) -> Result<Self, ()> {
 		if [Type::Array, Type::Ptr].contains(&self.typ) {
 			Ok((*self.ptr_to.clone().unwrap().borrow()).clone())
 		} else { Err(()) }
 	}
 
+	#[inline]
+	pub fn get_base_cell(&self) -> Self {
+		if let Some(_typ) = self.ptr_end {
+			Self::new(_typ)
+		} else {
+			panic!("cannot extract base type from non-pointer.");
+		}
+	}
+
+	#[inline]
 	pub fn make_func(ret_typ: Self, arg_typs: Vec<TypeCellRef>) -> Self {
 		let _ret_typ = Some(Rc::new(RefCell::new(ret_typ)));
 		let _arg_typs = Some(arg_typs);
 		TypeCell { typ: Type::Func, ret_typ: _ret_typ, arg_typs: _arg_typs, ..Default::default() }
+	}
+
+	#[inline]
+	pub fn flatten_size(&self) -> usize {
+		let (dim, _) = self.array_dim();
+		dim.iter().product::<usize>()
 	}
 
 	pub fn bytes(&self) -> usize {

--- a/rscc/src/typecell.rs
+++ b/rscc/src/typecell.rs
@@ -156,8 +156,12 @@ impl TypeCell {
 	fn get_type_string(&self, s: impl Into<String>) -> String {
 		let s = s.into();
 		if let Some(deref) = &self.ptr_to {
-			let string = if let Some(size) = self.array_size {
-				format!("{}[{}]", s, size)
+			let string = if self.typ == Type::Array {
+				if let Some(size) = self.array_size {
+					format!("{}[{}]", s, size)
+				} else {
+					format!("{}[]", s)
+				}
 			} else if deref.borrow().typ == Type::Array {
 				format!(" ({}*)", s)
 			} else {


### PR DESCRIPTION
`int x = 10, y = 10;` のような書き方をサポートするだけなら簡単だが、配列はそうはいかない
- 各要素の値を代入する処理をジェネレータができるように処理しなければならない
- 例えば、[chibicc](https://github.com/rui314/chibicc/blob/main/parse.c) の実装だと `Initializer` 構造体を定義している